### PR TITLE
saveFiles: Adds saveFile() with autosaving to `test.txt`

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -26,6 +26,7 @@ func EditorView() *tview.TextView {
 		}
 		State.TextView.SetText(State.Buffer)
 		State.App.Draw()
+		saveFile()
 		return nil
 	})
 	State.TextView.SetText("")

--- a/fileio.go
+++ b/fileio.go
@@ -1,0 +1,14 @@
+package justext
+
+import (
+	"io/ioutil"
+)
+
+func saveFile() bool {
+	d1 := []byte(State.Buffer)
+	err := ioutil.WriteFile(State.Filename, d1, 0700)
+	if err != nil {
+		panic(err)
+	}
+	return true
+}

--- a/justext.go
+++ b/justext.go
@@ -7,6 +7,7 @@ type EditorState struct {
 	App      *tview.Application
 	TextView *tview.TextView
 	Cursor   int
+	Filename string
 }
 
 var State EditorState
@@ -14,6 +15,7 @@ var State EditorState
 func Run() {
 	State = EditorState{}
 
+	State.Filename = "test.txt"
 	grid := tview.NewGrid().
 		SetRows(1, 0, 1).
 		SetBorders(true).


### PR DESCRIPTION
We created a new function that uses io/ioutil to save the contents of the state's buffer to a file with the state's filename. The state's `Filename` attribute was also added in this commit.