### PR TITLE
Bug Fix: Autoloads buffer into textView

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -28,6 +28,6 @@ func EditorView() *tview.TextView {
 		State.App.Draw()
 		return nil
 	})
-	State.TextView.SetText("")
+	State.TextView.SetText(State.Buffer)
 	return State.TextView
 }


### PR DESCRIPTION
Before: The textView would open and be empty until a key was pressed.
After: The textView opens with the buffer loaded.